### PR TITLE
feat: bump prime-cli to v0.5.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Description
+
+<!-- Describe the change and why it's being made. Include any relevant context, motivation, or background. -->
+
+## Type of Change
+
+<!-- Check all that apply. -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Dependency update
+- [ ] Refactor / cleanup
+- [ ] Other (describe below)
+
+## Checklist
+
+- [ ] Tests included / updated
+- [ ] Changelog updated
+- [ ] Version bump if needed

--- a/Formula/prime-cli.rb
+++ b/Formula/prime-cli.rb
@@ -1,10 +1,10 @@
 class PrimeCli < Formula
   desc "Coinbase Prime command-line interface (CLI) "
   homepage "https://github.com/coinbase-samples/prime-cli"
-  url "https://github.com/coinbase-samples/prime-cli/archive/refs/tags/v0.4.2.tar.gz"
-  sha256 "ca4350be1ef499fecb0a441873a8d2617dd60df1d5fc08941a219f446ff571fe"
+  url "https://github.com/coinbase-samples/prime-cli/archive/refs/tags/v0.5.0.tar.gz"
+  sha256 "8d82554769cccd4d7584832daf25d09fb6a9d0e91dc95a0267b1f9f5075e41a8"
   license "Apache-2.0"
-  version "0.4.2"
+  version "0.5.0"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
## Description

Bumps the `prime-cli` Homebrew formula from v0.4.2 to v0.5.0, pinning the v0.5.0 source tarball SHA256. Also adds a pull request template for future tap contributions.

Release: https://github.com/coinbase-samples/prime-cli/releases/tag/v0.5.0

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Dependency update
- [ ] Refactor / cleanup
- [x] Other (describe below)

Formula version bump for `prime-cli` v0.5.0.

## Checklist

- [ ] Tests included / updated
- [ ] Changelog updated
- [x] Version bump if needed


Made with [Cursor](https://cursor.com)